### PR TITLE
Update ip4r to version 2.3

### DIFF
--- a/ip4r.yaml
+++ b/ip4r.yaml
@@ -1,3 +1,3 @@
 homepage: https://github.com/RhodiumToad/ip4r
-url: https://github.com/RhodiumToad/ip4r/archive/2.2.tar.gz
-sha1: 670495ceff8e4f02eecc1137794cc07ae1f92a35
+url: https://github.com/RhodiumToad/ip4r/archive/2.3.tar.gz
+sha1: a7473bc322c94209226b79ec9eb09ca92b6660ca


### PR DESCRIPTION
Version 2.2 no longer builds with PostgreSQL 11